### PR TITLE
Adjust SSHD settings

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -193,9 +193,9 @@
                         "inline": [
                             "echo \"Starting sshd settings changes\"",
                             "sudo sed -i 's:^#\\?X11Forwarding yes$:X11Forwarding no:g' /etc/ssh/sshd_config",
-                            "sudo sed -i 's:^#\\?MaxAuthTries [0-9]\+$:MaxAuthTries 6:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\\?MaxAuthTries [0-9]\\+$:MaxAuthTries 6:g' /etc/ssh/sshd_config",
                             "sudo sed -i 's:^#\\?PasswordAuthentication yes$:PasswordAuthentication no:g' /etc/ssh/sshd_config",
-                            "sudo sed -i 's:^#\\?PermitRootLogin .\+$:PermitRootLogin no:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\\?PermitRootLogin .\\+$:PermitRootLogin no:g' /etc/ssh/sshd_config",
                             "echo \"Completed sshd settings changes\""
                         ]
                     },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -192,10 +192,10 @@
                         "name": "Adjust sshd settings.",
                         "inline": [
                             "echo \"Starting sshd settings changes\"",
-                            "sudo sed -i 's:^#\?X11Forwarding yes$:X11Forwarding no:g' /etc/ssh/sshd_config",
-                            "sudo sed -i 's:^#\?MaxAuthTries [0-9]\+$:MaxAuthTries 6:g' /etc/ssh/sshd_config",
-                            "sudo sed -i 's:^#\?PasswordAuthentication yes$:PasswordAuthentication no:g' /etc/ssh/sshd_config",
-                            "sudo sed -i 's:^#\?PermitRootLogin .\+$:PermitRootLogin no:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\\?X11Forwarding yes$:X11Forwarding no:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\\?MaxAuthTries [0-9]\+$:MaxAuthTries 6:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\\?PasswordAuthentication yes$:PasswordAuthentication no:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\\?PermitRootLogin .\+$:PermitRootLogin no:g' /etc/ssh/sshd_config",
                             "echo \"Completed sshd settings changes\""
                         ]
                     },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -189,6 +189,18 @@
                     },
                     {
                         "type": "Shell",
+                        "name": "Adjust sshd settings.",
+                        "inline": [
+                            "echo \"Starting sshd settings changes\"",
+                            "sudo sed -i 's:^#\?X11Forwarding yes$:X11Forwarding no:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\?MaxAuthTries [0-9]\+$:MaxAuthTries 6:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\?PasswordAuthentication yes$:PasswordAuthentication no:g' /etc/ssh/sshd_config",
+                            "sudo sed -i 's:^#\?PermitRootLogin .\+$:PermitRootLogin no:g' /etc/ssh/sshd_config",
+                            "echo \"Completed sshd settings changes\""
+                        ]
+                    },
+                    {
+                        "type": "Shell",
                         "name": "Install Azure CLI",
                         "inline": [
                             "echo \"Starting Azure CLI install\"",


### PR DESCRIPTION
Couple minor SSHD changes to show how one could set daemon settings (in this case SSHD) as part of this image building process.

`X11Forwarding` -> `no`
`MaxAuthTries` -> `6` 
`PasswordAuthentication` -> `no`
`PermitRootLogin` -> `no`

This aligns with the AKS regulated cluster concerns as well.