### PR TITLE
Upgrade step can be flakey (e.g sshd update hangs the process)

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -183,7 +183,7 @@
                         "inline": [
                             "echo \"Starting apt-get update/upgrade\"",
                             "sudo apt-get -yq update",
-                            "sudo apt-get -yq upgrade",
+                            "# sudo apt-get -yq upgrade",
                             "echo \"Completed apt-get update/upgrade\""
                         ]
                     },


### PR DESCRIPTION
Disable that step to help the process be successful, but keep it in so users can decide if they want to do it or not.