### PR TITLE
feat (bicep): minor lint bug fixing 

### DIFF
--- a/azuredeploy.bicep
+++ b/azuredeploy.bicep
@@ -99,6 +99,7 @@ module applyAibNetworkingRoleToBuilderVirtualNetwork 'modules/aibNetworkRoleAssi
 
 @description('This is the image spec for our general purpose AKS jump box. This template can be used to build VM images as needed.')
 resource imgtJumpBoxSpec 'Microsoft.VirtualMachineImages/imageTemplates@2021-10-01' = {
+#disable-next-line use-stable-resource-identifiers
   name: imageTemplateName
   location: location
   dependsOn: [

--- a/createsubscriptionroles.bicep
+++ b/createsubscriptionroles.bicep
@@ -49,11 +49,11 @@ resource imageBuilderImageCreationRoleDefinition 'Microsoft.Authorization/roleDe
 
 output roleResourceIds object = {
   customImageBuilderImageCreationRole: {
-    guid: '${imageBuilderImageCreationRoleDefinition.name}'
-    resourceId: '${imageBuilderImageCreationRoleDefinition.id}'
+    guid: imageBuilderImageCreationRoleDefinition.name
+    resourceId: imageBuilderImageCreationRoleDefinition.id
   }
   customImageBuilderNetworkingRole: {
-    guid: '${imageBuilderNetworkingRoleDefinition.name}'
-    resourceId: '${imageBuilderNetworkingRoleDefinition.id}'
+    guid: imageBuilderNetworkingRoleDefinition.name
+    resourceId: imageBuilderNetworkingRoleDefinition.id
   }
 }


### PR DESCRIPTION
## WHY

We wanted to test the networking deployment for aks-baseline-regulated and found some low hanging fruits to incorporate to our biceps over here.


## WHAT Changed?

- remove not required string interpolation
- disable warnings on top of dynamic name generation 

## HOW to Test?

you deploy the aks-regulated and for jumpbox images builder you receive `0` warnings.